### PR TITLE
Remove the read_u8!() macro

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,17 +1,4 @@
 #[macro_export]
-macro_rules! read_u8 {
-    ($elf:ident, $io:ident) => ({
-        use byteorder::{LittleEndian, BigEndian, ReadBytesExt};
-        match $elf.ehdr.data {
-            types::ELFDATA2LSB => { $io.read_u8::<LittleEndian>() }
-            types::ELFDATA2MSB => { $io.read_u8::<BigEndian>() }
-            types::ELFDATANONE => { panic!("Unable to resolve file endianness"); }
-            _ => { panic!("Unable to resolve file endianness"); }
-        }
-    });
-}
-
-#[macro_export]
 macro_rules! read_u16 {
     ($elf:ident, $io:ident) => ({
         use byteorder::{LittleEndian, BigEndian, ReadBytesExt};


### PR DESCRIPTION
The read_u8!() macro is unnecessary since there are not endianness
considers reading a u8. Additionally, the macro is broken because it
tries to specialize the read_u8 function in the ReadBytesExt trait
for LittleEndian and BigEndian which is not supported by that API.