### PR TITLE
Vec<u8> values cannot be printed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ let text_scn = match file.get_section(".text") {
     None => panic!("Failed to look up .text section"),
 };
 
-println!("{}", text_scn.data);
+println!("{:?}", text_scn.data);
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Pure-Rust library for parsing ELF files
 ```rust
 extern crate elf;
 
-use std::env;
 use std::path::PathBuf;
 
 let path = PathBuf::from("/some/file/path");


### PR DESCRIPTION
So show the debug format instead.