### PR TITLE
Implement ReadBytesAt for owned CachedReadBytes

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -741,8 +741,8 @@ mod interface_tests {
     fn test_open_stream_with_cachedreadbytes() {
         let path = std::path::PathBuf::from("tests/samples/test1");
         let io = std::fs::File::open(path).expect("Could not open file.");
-        let mut c_io = CachedReadBytes::new(io);
-        let file = File::open_stream(&mut c_io).expect("Open test1");
+        let c_io = CachedReadBytes::new(io);
+        let file = File::open_stream(c_io).expect("Open test1");
         assert_eq!(file.ehdr.elftype, ObjectFileType(gabi::ET_EXEC));
     }
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -245,7 +245,7 @@ impl<R: Read + Seek> CachedReadBytes<R> {
 }
 
 #[cfg(feature = "std")]
-impl<R: Read + Seek> ReadBytesAt for &mut CachedReadBytes<R> {
+impl<R: Read + Seek> ReadBytesAt for CachedReadBytes<R> {
     fn read_bytes_at(&mut self, range: Range<usize>) -> Result<&[u8], ParseError> {
         if range.len() == 0 {
             return Ok(&[]);
@@ -459,7 +459,7 @@ mod read_bytes_tests {
     fn cached_read_bytes_multiple_non_overlapping_reference_lifetimes() {
         let data = [1u8, 2u8, 3u8, 4u8];
         let cur = Cursor::new(data);
-        let mut cached = &mut CachedReadBytes::new(cur);
+        let cached = &mut CachedReadBytes::new(cur);
 
         let bytes1 = cached
             .read_bytes_at(0..2)
@@ -475,7 +475,7 @@ mod read_bytes_tests {
     fn cached_read_bytes_multiple_overlapping_reference_lifetimes() {
         let data = [1u8, 2u8, 3u8, 4u8];
         let cur = Cursor::new(data);
-        let mut cached = &mut CachedReadBytes::new(cur);
+        let cached = &mut CachedReadBytes::new(cur);
 
         cached
             .load_bytes_at(0..2)


### PR DESCRIPTION
As suggested in #21
This changes it from being implemented for a &mut CachedReadBytes, which forced users to keep a separate variable for the reader when passing it to File::open_stream(). There wasn't a specific reason for it to be implemented that way, and it's actually something that tenuously even desireable, since ultimately CachedReadBytes is a more an internal wrapper used within the File for lazy parsing than something that a user of the interface will want to keep around and use themselves for other things.