### PR TITLE
Implement core::error::Error for ParsingError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ name = "elf"
 default = ["std", "to_str"]
 std = []
 to_str = []
+nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@
 //! ```
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(all(feature = "nightly", not(feature = "std")), feature(error_in_core))]
 
 pub mod abi;
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -78,8 +78,30 @@ impl std::error::Error for ParseError {
             ParseError::Utf8Error(ref err) => Some(err),
             ParseError::TryFromSliceError(ref err) => Some(err),
             ParseError::TryFromIntError(ref err) => Some(err),
-            #[cfg(feature = "std")]
             ParseError::IOError(ref err) => Some(err),
+        }
+    }
+}
+
+#[cfg(all(feature = "nightly", not(feature = "std")))]
+impl core::error::Error for ParseError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match *self {
+            ParseError::BadMagic(_) => None,
+            ParseError::UnsupportedElfClass(_) => None,
+            ParseError::UnsupportedElfEndianness(_) => None,
+            ParseError::UnsupportedVersion(_) => None,
+            ParseError::BadOffset(_) => None,
+            ParseError::StringTableMissingNul(_) => None,
+            ParseError::BadEntsize(_) => None,
+            ParseError::UnexpectedSectionType(_) => None,
+            ParseError::UnexpectedSegmentType(_) => None,
+            ParseError::UnexpectedAlignment(_) => None,
+            ParseError::SliceReadError(_) => None,
+            ParseError::IntegerOverflow => None,
+            ParseError::Utf8Error(ref err) => Some(err),
+            ParseError::TryFromSliceError(ref err) => Some(err),
+            ParseError::TryFromIntError(ref err) => Some(err),
         }
     }
 }


### PR DESCRIPTION
This continues the discussion in #27.

Regarding cole14's last comment, this does work in my use case. However, implementing the trait `core::error::Error` instead of `std::error::Error` appears to be [an experimental feature](https://github.com/rust-lang/rust/issues/103765), which can only be used with nightly Rust.

For this reason, I've taken the liberty to add a new optional and non-default feature to the crate, `nightly`, since apparently it's not possible to deduce the release channel at compile time. Now:
- If the `std` feature **is** enabled, the original code is compiled.
- If the `std` feature is **not** enabled **and** the `nightly` feature **is** enabled, the experimental feature `#![feature(error_in_core)]` is used, and a similar† branch of the original code is compiled, one that substitutes `std` with `core` and does not match `ParseError::IOError`, which is only available with `std`.

† Maybe there's a better way to do this? I haven't looked extensively at the Rust preprocessor. Is there a `#define`-like capability?