### PR TITLE
Add `EM_CSKY`, `EM_LOONGARCH` and `EM_FRV`

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -502,6 +502,12 @@ pub const EM_AMDGPU: u16 = 224;
 pub const EM_RISCV: u16 = 243;
 /// Linux BPF
 pub const EM_BPF: u16 = 247;
+/// C-Sky
+pub const EM_CSKY: u16 = 252;
+/// LoongArch
+pub const EM_LOONGARCH: u16 = 258;
+/// Fujitsu FR-V
+pub const EM_FRV: u16 = 0x5441;
 
 // EV_* define constants for the ELF File Header's e_version field.
 // Represented as Elf32_Word in Elf32_Ehdr and Elf64_Word in Elf64_Ehdr which


### PR DESCRIPTION
Add some more `e_machine` members as per <https://github.com/torvalds/linux/blob/master/include/uapi/linux/elf-em.h>, including:

* `EM_CSKY` (252)
* `EM_LOONGARCH` (258)
* `EM_FRV` (0x5441)

https://github.com/torvalds/linux/blob/9946eaf552b194bb352c2945b54ff98c8193b3f1/include/uapi/linux/elf-em.h#L53-L55

Closes #45.