### PR TITLE
abi: add NT_X86_XSAVE_LAYOUT

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -1244,6 +1244,8 @@ pub const NT_386_TLS: u64 = 0x200;
 pub const NT_386_IOPERM: u64 = 0x201;
 /// x86 extended state using xsave
 pub const NT_X86_XSTATE: u64 = 0x202;
+/// XSAVE layout description
+pub const NT_X86_XSAVE_LAYOUT: u64 = 0x205;
 /// ARM VFP/NEON registers
 pub const NT_ARM_VFP: u64 = 0x400;
 /// ARM TLS register


### PR DESCRIPTION
Add the constant value for the NT_X86_XSAVE_LAYOUT note type. This was introduced in Linux kernel commit ba386777a3 and contains layout metadata describing the XSAVE register data.