### PR TITLE
Add release for reader in ElfStream

### DIFF
--- a/src/elf_stream.rs
+++ b/src/elf_stream.rs
@@ -679,6 +679,11 @@ impl<E: EndianParse, S: std::io::Read + std::io::Seek> ElfStream<E, S> {
             buf,
         ))
     }
+
+    /// Releases the reader from the [ElfStream] struct
+    pub fn release(self) -> S {
+        self.reader.reader
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This just adds a release function to get back the reader from ElfStream. This prevents forcing people to clone readers for an input file if they still need the reader for other purposes