### PR TITLE
Fix Elf32_Sym: change st_shndx from u32 to u16

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -17,7 +17,7 @@ pub struct Elf32_Sym {
     pub st_size: u32,
     pub st_info: u8,
     pub st_other: u8,
-    pub st_shndx: u32,
+    pub st_shndx: u16,
 }
 
 /// C-style 64-bit ELF Symbol definition


### PR DESCRIPTION
The st_shndx field in Elf32_Sym was incorrectly defined as u32 instead of u16.

This fixed #56 